### PR TITLE
Refactor: improved error lines cannot be tracked because of already c…

### DIFF
--- a/Saga/API/SagaRegistry.ts
+++ b/Saga/API/SagaRegistry.ts
@@ -1,6 +1,7 @@
 import { TxContext } from '../../UnitOfWork/main';
 import { SagaOrchestrator } from './SagaOrchestrator';
 import {
+    ErrChannelNotFound,
     ErrDeadSagaSession,
     ErrDuplicateSaga,
     ErrEventConsumptionError,
@@ -140,12 +141,14 @@ export abstract class ChannelToSagaRegistry<
         } catch (e) {
             if (
                 e instanceof ErrSagaSessionNotFound ||
+                e instanceof ErrChannelNotFound ||
                 e instanceof ErrStepNotFound ||
                 e instanceof ErrSagaNotFound ||
                 e instanceof ErrDeadSagaSession
             ) {
                 console.info(e); // this should be sent to a logger
             } else {
+                console.error(e);
                 throw new ErrEventConsumptionError();
             }
         }

--- a/Saga/API/SagaRegistry.ts
+++ b/Saga/API/SagaRegistry.ts
@@ -60,7 +60,7 @@ export class SagaRegistry<Tx extends TxContext> {
 
     public registerSaga(saga: AbstractSaga<Tx, saga.SagaSessionArguments, saga.SagaSession>) {
         if (this.hasSagaWithName(saga.getName())) {
-            throw ErrDuplicateSaga;
+            throw new ErrDuplicateSaga();
         }
 
         this.sagas.push(saga);
@@ -114,7 +114,7 @@ export class SagaRegistry<Tx extends TxContext> {
         this.registryMutex.release();
 
         if (!saga || !(saga instanceof sagaClass)) {
-            throw ErrSagaNotFound;
+            throw new ErrSagaNotFound();
         }
 
         await this.orchestrator.startSaga<A, I>(sessionArg, saga as AbstractSaga<TxContext, A, I>);
@@ -137,10 +137,10 @@ export abstract class ChannelToSagaRegistry<
             const commandWithOrigin = this.parseMessageWithOrigin(command as M);
             return this._sagaRegistry.consumeEvent(commandWithOrigin);
         } catch (e) {
-            if (e === ErrSagaSessionNotFound || e === ErrStepNotFound || e === ErrSagaNotFound) {
+            if (e instanceof ErrSagaSessionNotFound || e instanceof ErrStepNotFound || e instanceof ErrSagaNotFound) {
                 console.error(e); // this should be sent to a logger
             } else {
-                throw ErrEventConsumptionError;
+                throw new ErrEventConsumptionError();
             }
         }
     }

--- a/Saga/Errors/index.ts
+++ b/Saga/Errors/index.ts
@@ -1,9 +1,60 @@
-export const ErrDuplicateSaga = new Error("Duplicate saga in registry");
-export const ErrDeadSagaSession = new Error("Session has already been completed or failed");
-export const ErrChannelNotFound = new Error("Channel not found");
-export const ErrStepNotFound = new Error("Step not found");
-export const ErrSagaNotFound = new Error("Saga not found");
-export const ErrSagaSessionNotFound = new Error("Saga session not found");
-export const ErrEventConsumptionError = new Error("Error consuming event");
-export const ErrLocalInvocationError = new Error("Error during local invocation");
-export const ErrLocalCompensationError = new Error("Error during local compensation");
+abstract class SagaError extends Error {
+    protected constructor(message: string) {
+        super(message);
+        this.name = 'SagaError';
+    }
+}
+
+export class ErrDuplicateSaga extends SagaError {
+    constructor() {
+        super('Duplicate saga in registry');
+    }
+}
+
+export class ErrDeadSagaSession extends SagaError {
+    constructor() {
+        super('Session has already been completed or failed');
+    }
+}
+
+export class ErrChannelNotFound extends SagaError {
+    constructor() {
+        super('Channel not found');
+    }
+}
+
+export class ErrStepNotFound extends SagaError {
+    constructor() {
+        super('Step not found');
+    }
+}
+
+export class ErrSagaNotFound extends SagaError {
+    constructor() {
+        super('Saga not found');
+    }
+}
+
+export class ErrSagaSessionNotFound extends SagaError {
+    constructor() {
+        super('Saga session not found');
+    }
+}
+
+export class ErrLocalInvocationError extends SagaError {
+    constructor() {
+        super('Error during local invocation');
+    }
+}
+
+export class ErrEventConsumptionError extends SagaError {
+    constructor() {
+        super('Error consuming event');
+    }
+}
+
+export class ErrLocalCompensationError extends SagaError {
+    constructor() {
+        super('Error during local compensation');
+    }
+}


### PR DESCRIPTION
Refactor: improved error lines cannot be tracked because of already created error instance

디버그 어렵던 이유 발견!

* 디버그 가시성을 향상했습니다.
Errors/index에 에러 인스턴스가 이미 생성되어 있어서, exception throw line이 제대로 인터프리터에게 catch되지 않고 Errors/index를 가르키던 문제를 수정했습니다.